### PR TITLE
Replace deprecated function in Reagent

### DIFF
--- a/dev/src/cljs/rui_demo/core.cljs
+++ b/dev/src/cljs/rui_demo/core.cljs
@@ -1,14 +1,14 @@
 (ns rui-demo.core
   (:require
-    [goog.dom :as dom]
-    [reagent.core :as reagent]
-    [re-frame.core :refer [dispatch dispatch-sync clear-subscription-cache! subscribe reg-sub]]
-    [rui-demo.buttons :refer [buttons-demo]]
-    [rui-demo.icons :refer [icons-demo]]
-    [rui-demo.flash :refer [flash-demo]]
-    [rui-demo.forms :refer [forms-demo]]
-    [rui-demo.modals :refer [modals-demo]]))
-
+   [goog.dom :as dom]
+   [re-frame.core :refer [dispatch dispatch-sync clear-subscription-cache! subscribe reg-sub]]
+   [reagent.core :as reagent]
+   [reagent.dom :as rdom]
+   [rui-demo.buttons :refer [buttons-demo]]
+   [rui-demo.flash :refer [flash-demo]]
+   [rui-demo.forms :refer [forms-demo]]
+   [rui-demo.icons :refer [icons-demo]]
+   [rui-demo.modals :refer [modals-demo]]))
 
 (reg-sub
   :app
@@ -35,7 +35,7 @@
 
 (defn- mount-root!
   [app-element]
-  (reagent/render [main] app-element))
+  (rdom/render [main] app-element))
 
 
 (defn ^:export run

--- a/project.clj
+++ b/project.clj
@@ -16,8 +16,8 @@
                    :dependencies [[org.clojure/clojure "1.9.0"]
                                   [org.clojure/clojurescript "1.10.339"]
                                   [binaryage/devtools "0.9.10"]
-                                  [reagent "0.8.1"]
-                                  [re-frame "0.10.5"]
+                                  [reagent "0.10.0"]
+                                  [re-frame "0.12.0"]
                                   [re-frisk "0.5.4"]]}}
 
   :cljsbuild

--- a/src/cljs/rui/modals/components.cljs
+++ b/src/cljs/rui/modals/components.cljs
@@ -1,10 +1,11 @@
 (ns rui.modals.components
   (:require
-    [goog.dom.classlist :as classes]
-    [goog.style :as style]
-    [goog.string :refer [unescapeEntities]]
     [ccn.core :refer [bem css-class twbs]]
+    [goog.dom.classlist :as classes]
+    [goog.string :refer [unescapeEntities]]
+    [goog.style :as style]
     [reagent.core :as reagent]
+    [reagent.dom :as dom]
     [rui.modals.events]))
 
 
@@ -72,7 +73,7 @@
   "Toggles modal's visibility by modifing DOM (due Bootstrap's design)."
   [this]
   (let [state (reagent/props this)
-        el (reagent/dom-node this)
+        el (dom/dom-node this)
         modal-el (.querySelector el ".modal")
         backdrop-el (.querySelector el ".modal-backdrop")]
     (if (:opened? state)


### PR DESCRIPTION
Some functions are deprecated in Reagent 0.10.0, so don't use them

Fixes: #50